### PR TITLE
feat(chat): Make authentication failure messages more helpful

### DIFF
--- a/src/errors.ts
+++ b/src/errors.ts
@@ -2,6 +2,8 @@ import { IncomingMessage } from 'http';
 
 // tslint:disable max-classes-per-file
 
+export const UNOTFOUND = 'UNOTFOUND';
+
 /**
  * Base error for all fe2 stuff.
  * This also acts as a polyfill when building with ES5 target.

--- a/src/ws/Socket.ts
+++ b/src/ws/Socket.ts
@@ -11,7 +11,7 @@ import {
     IUserTimeout,
     IUserUpdate,
 } from '../defs/chat';
-import { AuthenticationFailedError, BadMessageError, NoMethodHandlerError, TimeoutError } from '../errors';
+import { AuthenticationFailedError, BadMessageError, NoMethodHandlerError, TimeoutError, UNOTFOUND } from '../errors';
 import { Reply } from './Reply';
 
 // The method of the authentication packet to store.
@@ -431,8 +431,12 @@ export class Socket extends EventEmitter {
             this.call(authMethod, this._authpacket, { force: true })
             .then(result => this.emit('authresult', result))
             .then(bang)
-            .catch(() => {
-                this.emit('error', new AuthenticationFailedError('?'));
+            .catch((e: Error) => {
+                let message = 'Authentication Failed, please check your credentials.'
+                if(e.message === UNOTFOUND) {
+                    message = 'Authentication Failed: User not found. Please check our guide at: https://aka.ms/unotfound'
+                }
+                this.emit('error', new AuthenticationFailedError(message));
                 this.close();
             });
         } else {

--- a/src/ws/Socket.ts
+++ b/src/ws/Socket.ts
@@ -432,9 +432,9 @@ export class Socket extends EventEmitter {
             .then(result => this.emit('authresult', result))
             .then(bang)
             .catch((e: Error) => {
-                let message = 'Authentication Failed, please check your credentials.'
-                if(e.message === UNOTFOUND) {
-                    message = 'Authentication Failed: User not found. Please check our guide at: https://aka.ms/unotfound'
+                let message = 'Authentication Failed, please check your credentials.';
+                if (e.message === UNOTFOUND) {
+                    message = 'Authentication Failed: User not found. Please check our guide at: https://aka.ms/unotfound';
                 }
                 this.emit('error', new AuthenticationFailedError(message));
                 this.close();


### PR DESCRIPTION
The troubleshooting guide let matt identify his issue in 30 seconds. But he didn't know the error was UNOTFOUND.

This calls it out better by not throwing the error context away.